### PR TITLE
Remove pytest ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.python-version

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+extends: default
+
+rules:
+  # yamllint doesn't like when we use yes and no for true and false,
+  # but that's pretty standard in Ansible.
+  truthy: disable

--- a/molecule/default/pytest.ini
+++ b/molecule/default/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = -p no:cacheprovider -p no:stepwise


### PR DESCRIPTION
It's no longer needed with the latest (3.10.1) version of `pytest`.